### PR TITLE
Add latency and network speed metrics to search cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -77,31 +77,159 @@ button, .card-hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
     position: relative;
     overflow: hidden;
-    border-radius: 6px;
-    display: flex;
-    flex-direction: column;
+    border-radius: 12px;
+    display: block;
+}
+
+.result-card {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 1rem;
+    min-height: 184px;
+    background: radial-gradient(circle at top left, rgba(0, 204, 255, 0.12), transparent 55%),
+        linear-gradient(135deg, rgba(18, 27, 41, 0.95), rgba(11, 18, 30, 0.92));
+}
+
+.result-card__media {
+    position: relative;
+    overflow: hidden;
+    background: #0b1018;
+}
+
+.result-card__media::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(12, 19, 31, 0.65), transparent 60%);
+    pointer-events: none;
+}
+
+.result-card__media img {
+    width: 100%;
     height: 100%;
+    object-fit: cover;
+    transition: transform 0.4s ease;
 }
 
-/* 确保卡片内容区域高度一致性 */
-.card-hover .flex-grow {
-    min-height: unset; /* 移除最小高度限制，让内容自然流动 */
+.result-card:hover .result-card__media img {
+    transform: scale(1.06);
+}
+
+.result-card__body {
+    padding: 1rem 1.1rem 1.1rem;
     display: flex;
     flex-direction: column;
+    gap: 0.9rem;
 }
 
-/* 针对不同长度的标题优化显示 */
-.card-hover h3 {
-    min-height: unset;
-    max-height: unset;
+.result-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+}
+
+.result-card__title {
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.35;
+    color: var(--text-color);
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
     -webkit-line-clamp: 2;
-    line-height: 1.2rem;
-    word-break: break-word; /* 允许在任何字符间断行 */
-    hyphens: auto; /* 允许断词 */
+    overflow: hidden;
+    word-break: break-word;
+    hyphens: auto;
+}
+
+.result-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+
+.result-card__description {
+    font-size: 0.82rem;
+    color: rgba(226, 232, 240, 0.72);
+    line-height: 1.45;
+    max-height: 2.9em;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.result-card__footer {
+    margin-top: auto;
+    padding-top: 0.8rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.result-card__source {
+    display: flex;
+    align-items: center;
+}
+
+.result-card__metrics {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.result-card--no-cover {
+    grid-template-columns: 1fr;
+    text-align: center;
+}
+
+.result-card--no-cover .result-card__body {
+    align-items: center;
+    padding: 1.25rem 1.2rem 1.3rem;
+}
+
+.result-card--no-cover .result-card__description {
+    text-align: center;
+}
+
+.result-card--no-cover .result-card__footer {
+    justify-content: center;
+}
+
+.result-card--no-cover .result-card__metrics {
+    justify-content: center;
+}
+
+@media (max-width: 1024px) {
+    .result-card {
+        grid-template-columns: 110px 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .result-card {
+        grid-template-columns: 1fr;
+    }
+
+    .result-card__media {
+        height: 180px;
+    }
+
+    .result-card__body {
+        padding: 1rem 1rem 1.2rem;
+    }
+
+    .result-card__footer {
+        justify-content: center;
+    }
+
+    .result-card__metrics {
+        justify-content: center;
+    }
 }
 
 .card-hover::before {
@@ -939,63 +1067,6 @@ body {
     .custom-title-scroll {
         font-size: 1rem;
     }
-}
-
-/* 搜索结果卡片优化：横向布局 */
-.search-card-img-container {
-    width: 100px;  /* 增加宽度，从80px到100px */
-    height: 150px; /* 增加高度，从120px到150px */
-    overflow: hidden;
-    background-color: #191919;
-}
-
-/* 确保图片不会被拉伸，并且能够正确显示 */
-.search-card-img-container img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-}
-
-/* 针对搜索结果卡片修改网格布局以适应横向卡片 */
-@media (max-width: 640px) {
-    #results {
-        grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
-    }
-}
-
-/* 响应式调整：在小屏幕上依然保持较好的视觉效果 */
-@media (min-width: 641px) and (max-width: 768px) {
-    #results {
-        grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-    }
-}
-
-/* 调整网格布局，减少每行卡片数量以适应更大尺寸的卡片 */
-@media (min-width: 769px) and (max-width: 1024px) {
-    #results {
-        grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
-    }
-}
-
-@media (min-width: 1025px) {
-    #results {
-        grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
-    }
-}
-
-/* 优化卡片内元素间距与排版 */
-.card-hover .p-3 {
-    padding: 0.85rem;
-}
-
-/* 增加卡片内字体大小 */
-.card-hover h3 {
-    font-size: 0.95rem; /* 增加标题字体大小 */
-    line-height: 1.3rem;
-}
-
-.card-hover p {
-    font-size: 0.8rem; /* 增加描述字体大小 */
 }
 
 /* 确保Toast显示在顶层并有适当的转换效果 */

--- a/css/styles.css
+++ b/css/styles.css
@@ -125,6 +125,95 @@ button, .card-hover {
     left: 100%;
 }
 
+.source-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.6rem;
+    font-size: 0.75rem;
+    border-radius: 9999px;
+    background: linear-gradient(135deg, rgba(0, 204, 255, 0.18), rgba(0, 204, 255, 0.05));
+    color: var(--primary-light);
+    border: 1px solid rgba(0, 204, 255, 0.35);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    letter-spacing: 0.01em;
+    backdrop-filter: blur(6px);
+}
+
+.source-badge__dot {
+    width: 0.375rem;
+    height: 0.375rem;
+    border-radius: 9999px;
+    background: currentColor;
+    opacity: 0.85;
+}
+
+.tag-pill {
+    font-size: 0.72rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: 9999px;
+    background: rgba(148, 163, 184, 0.14);
+    color: rgba(226, 232, 240, 0.92);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    letter-spacing: 0.02em;
+    backdrop-filter: blur(4px);
+}
+
+.metric-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.7rem;
+    font-size: 0.72rem;
+    border-radius: 9999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(15, 22, 34, 0.6);
+    color: var(--text-muted);
+    letter-spacing: 0.02em;
+    backdrop-filter: blur(8px);
+    white-space: nowrap;
+}
+
+.metric-badge__dot {
+    width: 0.35rem;
+    height: 0.35rem;
+    border-radius: 9999px;
+    background: currentColor;
+    opacity: 0.75;
+}
+
+.metric-badge__label {
+    opacity: 0.85;
+}
+
+.metric-badge__value {
+    font-weight: 600;
+}
+
+.metric-badge--good {
+    background: rgba(16, 185, 129, 0.18);
+    border-color: rgba(16, 185, 129, 0.45);
+    color: #6ee7b7;
+}
+
+.metric-badge--warn {
+    background: rgba(234, 179, 8, 0.18);
+    border-color: rgba(234, 179, 8, 0.45);
+    color: #facc15;
+}
+
+.metric-badge--slow {
+    background: rgba(248, 113, 113, 0.2);
+    border-color: rgba(248, 113, 113, 0.5);
+    color: #fda4af;
+}
+
+.metric-badge--unknown {
+    background: rgba(148, 163, 184, 0.16);
+    border-color: rgba(148, 163, 184, 0.4);
+    color: #cbd5f5;
+}
+
 .gradient-text {
     background: linear-gradient(to right, var(--primary-color), var(--accent-color));
     -webkit-background-clip: text;
@@ -894,25 +983,19 @@ body {
     }
 }
 
-/* 优化卡片内元素间距 */
-.card-hover .p-2 {
-    padding: 0.75rem; /* 增加内边距 */
+/* 优化卡片内元素间距与排版 */
+.card-hover .p-3 {
+    padding: 0.85rem;
 }
 
 /* 增加卡片内字体大小 */
 .card-hover h3 {
     font-size: 0.95rem; /* 增加标题字体大小 */
     line-height: 1.3rem;
-    margin-bottom: 0.5rem;
 }
 
 .card-hover p {
     font-size: 0.8rem; /* 增加描述字体大小 */
-}
-
-/* 优化卡片内元素间距 */
-.card-hover .p-2 {
-    padding: 0.5rem;
 }
 
 /* 确保Toast显示在顶层并有适当的转换效果 */

--- a/js/app.js
+++ b/js/app.js
@@ -739,6 +739,8 @@ async function search() {
                 .replace(/"/g, '&quot;');
             const sourceInfo = item.source_name ?
                 `<span class="bg-[#222] text-xs px-1.5 py-0.5 rounded-full">${item.source_name}</span>` : '';
+            const latencyDisplay = Number.isFinite(item.latencyMs) ? `${item.latencyMs}ms` : '未知';
+            const speedDisplay = Number.isFinite(item.speedKbps) ? `${item.speedKbps} KB/s` : '未知';
             const sourceCode = item.source_code || '';
 
             // 添加API URL属性，用于详情获取
@@ -782,6 +784,10 @@ async function search() {
                             
                             <div class="flex justify-between items-center mt-1 pt-1 border-t border-gray-800">
                                 ${sourceInfo ? `<div>${sourceInfo}</div>` : '<div></div>'}
+                                <div class="text-xs text-gray-500 text-right leading-tight">
+                                    <div>延迟: ${latencyDisplay}</div>
+                                    <div>网速: ${speedDisplay}</div>
+                                </div>
                                 <!-- 接口名称过长会被挤变形
                                 <div>
                                     <span class="text-gray-500 flex items-center hover:text-blue-400 transition-colors">

--- a/js/app.js
+++ b/js/app.js
@@ -733,14 +733,19 @@ async function search() {
         // 指标和显示辅助方法
         const formatSpeed = (speed) => {
             if (!Number.isFinite(speed) || speed <= 0) return '未知';
-            if (speed >= 1024) {
-                const mb = speed / 1024;
-                return `${mb >= 10 ? Math.round(mb) : mb.toFixed(1)} MB/s`;
+            if (speed >= 2048) {
+                return `${Math.round(speed / 1024)} MB/s`;
             }
-            if (speed >= 100) {
+            if (speed >= 1024) {
+                return `${(speed / 1024).toFixed(1)} MB/s`;
+            }
+            if (speed >= 10) {
                 return `${Math.round(speed)} KB/s`;
             }
-            return `${speed.toFixed(1)} KB/s`;
+            if (speed >= 1) {
+                return `${speed.toFixed(1)} KB/s`;
+            }
+            return `${Math.max(speed * 1024, 1).toFixed(0)} B/s`;
         };
 
         const getLatencyClass = (latency) => {
@@ -783,65 +788,55 @@ async function search() {
                     <span class="metric-badge__value">${speedDisplay}</span>
                 </span>`;
 
-            // 添加API URL属性，用于详情获取
             const apiUrlAttr = item.api_url ?
                 `data-api-url="${item.api_url.replace(/"/g, '&quot;')}"` : '';
 
-            // 修改为水平卡片布局，图片在左侧，文本在右侧，并优化样式
             const hasCover = item.vod_pic && item.vod_pic.startsWith('http');
+            const cardClasses = ['card-hover', 'group', 'result-card', 'cursor-pointer'];
+            if (hasCover) {
+                cardClasses.push('relative');
+            } else {
+                cardClasses.push('result-card--no-cover');
+            }
+
+            const safeType = (item.type_name || '').toString().replace(/</g, '&lt;');
+            const tags = [];
+            if (safeType) {
+                tags.push(`<span class="tag-pill">${safeType}</span>`);
+            }
+            if (item.vod_year) {
+                tags.push(`<span class="tag-pill">${item.vod_year}</span>`);
+            }
+            const tagsMarkup = tags.length ? `<div class="result-card__tags">${tags.join('')}</div>` : '';
+
+            const remarks = (item.vod_remarks || '暂无介绍').toString().replace(/</g, '&lt;');
 
             return `
-                <div class="card-hover group relative overflow-hidden cursor-pointer h-full"
-                     onclick="showDetails('${safeId}','${safeName}','${sourceCode}')" ${apiUrlAttr}>
-                    <div class="flex h-full">
-                        ${hasCover ? `
-                        <div class="relative flex-shrink-0 search-card-img-container">
-                            <img src="${item.vod_pic}" alt="${safeName}"
-                                 class="h-full w-full object-cover transition-transform hover:scale-110"
-                                 onerror="this.onerror=null; this.src='https://via.placeholder.com/300x450?text=无封面'; this.classList.add('object-contain');" 
-                                 loading="lazy">
-                            <div class="absolute inset-0 bg-gradient-to-r from-black/30 to-transparent"></div>
-                        </div>` : ''}
-                        
-                        <div class="p-3 flex flex-col flex-grow gap-2">
-                            <div class="flex-grow flex flex-col gap-2">
-                                <h3 class="font-semibold text-[0.95rem] leading-tight break-words line-clamp-2 ${hasCover ? '' : 'text-center'}" title="${safeName}">${safeName}</h3>
+                <article class="${cardClasses.join(' ')}" role="button" tabindex="0"
+                         onclick="showDetails('${safeId}','${safeName}','${sourceCode}')"
+                         onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();showDetails('${safeId}','${safeName}','${sourceCode}');}" ${apiUrlAttr}>
+                    ${hasCover ? `
+                    <div class="result-card__media">
+                        <img src="${item.vod_pic}" alt="${safeName}"
+                             onerror="this.onerror=null; this.src='https://via.placeholder.com/300x450?text=无封面'; this.classList.add('object-contain');"
+                             loading="lazy">
+                    </div>` : ''}
 
-                                <div class="flex flex-wrap ${hasCover ? '' : 'justify-center'} gap-1.5">
-                                    ${(item.type_name || '').toString().replace(/</g, '&lt;') ?
-                    `<span class="tag-pill">
-                                          ${(item.type_name || '').toString().replace(/</g, '&lt;')}
-                                      </span>` : ''}
-                                    ${(item.vod_year || '') ?
-                    `<span class="tag-pill">
-                                          ${item.vod_year}
-                                      </span>` : ''}
-                                </div>
-                                <p class="text-[0.8rem] text-gray-400/90 line-clamp-2 overflow-hidden ${hasCover ? '' : 'text-center'}">
-                                    ${(item.vod_remarks || '暂无介绍').toString().replace(/</g, '&lt;')}
-                                </p>
+                    <div class="result-card__body">
+                        <header class="result-card__header">
+                            <h3 class="result-card__title" title="${safeName}">${safeName}</h3>
+                            ${tagsMarkup}
+                        </header>
+                        <p class="result-card__description">${remarks}</p>
+                        <footer class="result-card__footer">
+                            ${sourceInfo ? `<div class="result-card__source">${sourceInfo}</div>` : '<span></span>'}
+                            <div class="result-card__metrics">
+                                ${latencyBadge}
+                                ${speedBadge}
                             </div>
-
-                            <div class="flex items-center justify-between pt-2 border-t border-white/5">
-                                ${sourceInfo ? `<div>${sourceInfo}</div>` : '<div></div>'}
-                                <div class="flex items-center gap-1.5 flex-wrap justify-end">
-                                    ${latencyBadge}
-                                    ${speedBadge}
-                                </div>
-                                <!-- 接口名称过长会被挤变形
-                                <div>
-                                    <span class="text-gray-500 flex items-center hover:text-blue-400 transition-colors">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-                                        </svg>
-                                        播放
-                                    </span>
-                                </div>
-                                -->
-                            </div>
-                        </div>
+                        </footer>
                     </div>
-                </div>
+                </article>
             `;
         }).join('');
 

--- a/js/app.js
+++ b/js/app.js
@@ -730,6 +730,33 @@ async function search() {
             });
         }
 
+        // 指标和显示辅助方法
+        const formatSpeed = (speed) => {
+            if (!Number.isFinite(speed) || speed <= 0) return '未知';
+            if (speed >= 1024) {
+                const mb = speed / 1024;
+                return `${mb >= 10 ? Math.round(mb) : mb.toFixed(1)} MB/s`;
+            }
+            if (speed >= 100) {
+                return `${Math.round(speed)} KB/s`;
+            }
+            return `${speed.toFixed(1)} KB/s`;
+        };
+
+        const getLatencyClass = (latency) => {
+            if (!Number.isFinite(latency)) return 'metric-badge--unknown';
+            if (latency <= 200) return 'metric-badge--good';
+            if (latency <= 500) return 'metric-badge--warn';
+            return 'metric-badge--slow';
+        };
+
+        const getSpeedClass = (speed) => {
+            if (!Number.isFinite(speed) || speed <= 0) return 'metric-badge--unknown';
+            if (speed >= 1024) return 'metric-badge--good';
+            if (speed >= 256) return 'metric-badge--warn';
+            return 'metric-badge--slow';
+        };
+
         // 添加XSS保护，使用textContent和属性转义
         const safeResults = allResults.map(item => {
             const safeId = item.vod_id ? item.vod_id.toString().replace(/[^\w-]/g, '') : '';
@@ -738,10 +765,23 @@ async function search() {
                 .replace(/>/g, '&gt;')
                 .replace(/"/g, '&quot;');
             const sourceInfo = item.source_name ?
-                `<span class="bg-[#222] text-xs px-1.5 py-0.5 rounded-full">${item.source_name}</span>` : '';
+                `<span class="source-badge">
+                    <span class="source-badge__dot"></span>
+                    <span>${item.source_name}</span>
+                </span>` : '';
             const latencyDisplay = Number.isFinite(item.latencyMs) ? `${item.latencyMs}ms` : '未知';
-            const speedDisplay = Number.isFinite(item.speedKbps) ? `${item.speedKbps} KB/s` : '未知';
+            const speedDisplay = formatSpeed(item.speedKBps);
             const sourceCode = item.source_code || '';
+            const latencyBadge = `<span class="metric-badge ${getLatencyClass(item.latencyMs)}">
+                    <span class="metric-badge__dot"></span>
+                    <span class="metric-badge__label">延迟</span>
+                    <span class="metric-badge__value">${latencyDisplay}</span>
+                </span>`;
+            const speedBadge = `<span class="metric-badge ${getSpeedClass(item.speedKBps)}">
+                    <span class="metric-badge__dot"></span>
+                    <span class="metric-badge__label">网速</span>
+                    <span class="metric-badge__value">${speedDisplay}</span>
+                </span>`;
 
             // 添加API URL属性，用于详情获取
             const apiUrlAttr = item.api_url ?
@@ -751,42 +791,42 @@ async function search() {
             const hasCover = item.vod_pic && item.vod_pic.startsWith('http');
 
             return `
-                <div class="card-hover bg-[#111] rounded-lg overflow-hidden cursor-pointer transition-all hover:scale-[1.02] h-full shadow-sm hover:shadow-md" 
+                <div class="card-hover group relative overflow-hidden cursor-pointer h-full"
                      onclick="showDetails('${safeId}','${safeName}','${sourceCode}')" ${apiUrlAttr}>
                     <div class="flex h-full">
                         ${hasCover ? `
                         <div class="relative flex-shrink-0 search-card-img-container">
-                            <img src="${item.vod_pic}" alt="${safeName}" 
-                                 class="h-full w-full object-cover transition-transform hover:scale-110" 
+                            <img src="${item.vod_pic}" alt="${safeName}"
+                                 class="h-full w-full object-cover transition-transform hover:scale-110"
                                  onerror="this.onerror=null; this.src='https://via.placeholder.com/300x450?text=无封面'; this.classList.add('object-contain');" 
                                  loading="lazy">
                             <div class="absolute inset-0 bg-gradient-to-r from-black/30 to-transparent"></div>
                         </div>` : ''}
                         
-                        <div class="p-2 flex flex-col flex-grow">
-                            <div class="flex-grow">
-                                <h3 class="font-semibold mb-2 break-words line-clamp-2 ${hasCover ? '' : 'text-center'}" title="${safeName}">${safeName}</h3>
-                                
-                                <div class="flex flex-wrap ${hasCover ? '' : 'justify-center'} gap-1 mb-2">
+                        <div class="p-3 flex flex-col flex-grow gap-2">
+                            <div class="flex-grow flex flex-col gap-2">
+                                <h3 class="font-semibold text-[0.95rem] leading-tight break-words line-clamp-2 ${hasCover ? '' : 'text-center'}" title="${safeName}">${safeName}</h3>
+
+                                <div class="flex flex-wrap ${hasCover ? '' : 'justify-center'} gap-1.5">
                                     ${(item.type_name || '').toString().replace(/</g, '&lt;') ?
-                    `<span class="text-xs py-0.5 px-1.5 rounded bg-opacity-20 bg-blue-500 text-blue-300">
+                    `<span class="tag-pill">
                                           ${(item.type_name || '').toString().replace(/</g, '&lt;')}
                                       </span>` : ''}
                                     ${(item.vod_year || '') ?
-                    `<span class="text-xs py-0.5 px-1.5 rounded bg-opacity-20 bg-purple-500 text-purple-300">
+                    `<span class="tag-pill">
                                           ${item.vod_year}
                                       </span>` : ''}
                                 </div>
-                                <p class="text-gray-400 line-clamp-2 overflow-hidden ${hasCover ? '' : 'text-center'} mb-2">
+                                <p class="text-[0.8rem] text-gray-400/90 line-clamp-2 overflow-hidden ${hasCover ? '' : 'text-center'}">
                                     ${(item.vod_remarks || '暂无介绍').toString().replace(/</g, '&lt;')}
                                 </p>
                             </div>
-                            
-                            <div class="flex justify-between items-center mt-1 pt-1 border-t border-gray-800">
+
+                            <div class="flex items-center justify-between pt-2 border-t border-white/5">
                                 ${sourceInfo ? `<div>${sourceInfo}</div>` : '<div></div>'}
-                                <div class="text-xs text-gray-500 text-right leading-tight">
-                                    <div>延迟: ${latencyDisplay}</div>
-                                    <div>网速: ${speedDisplay}</div>
+                                <div class="flex items-center gap-1.5 flex-wrap justify-end">
+                                    ${latencyBadge}
+                                    ${speedBadge}
                                 </div>
                                 <!-- 接口名称过长会被挤变形
                                 <div>

--- a/js/search.js
+++ b/js/search.js
@@ -23,29 +23,55 @@ async function searchByAPIAndKeyWord(apiId, query) {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 8000);
         
+        const requestStart = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
         const response = await fetch(PROXY_URL + encodeURIComponent(apiUrl), {
             headers: API_CONFIG.search.headers,
             signal: controller.signal
         });
-        
+
         clearTimeout(timeoutId);
-        
+
         if (!response.ok) {
             return [];
         }
-        
-        const data = await response.json();
-        
+
+        const responseEnd = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+        const responseText = await response.text();
+
+        let data;
+        try {
+            data = JSON.parse(responseText);
+        } catch (parseError) {
+            console.warn(`API ${apiId} 返回的搜索结果无法解析:`, parseError);
+            return [];
+        }
+
+        const durationMs = responseEnd - requestStart;
+        const durationSeconds = durationMs > 0 ? durationMs / 1000 : 0;
+        let payloadSizeBytes = 0;
+        try {
+            payloadSizeBytes = new TextEncoder().encode(responseText).length;
+        } catch (encoderError) {
+            // TextEncoder 在极少数环境中不可用，回退到字符串长度估算
+            payloadSizeBytes = responseText.length * 2;
+        }
+        const speedKbps = durationSeconds > 0
+            ? Math.round((payloadSizeBytes / 1024) / durationSeconds)
+            : null;
+        const latencyMs = Math.round(durationMs);
+
         if (!data || !data.list || !Array.isArray(data.list) || data.list.length === 0) {
             return [];
         }
-        
+
         // 处理第一页结果
         const results = data.list.map(item => ({
             ...item,
             source_name: apiName,
             source_code: apiId,
-            api_url: apiId.startsWith('custom_') ? getCustomApiInfo(apiId.replace('custom_', ''))?.url : undefined
+            api_url: apiId.startsWith('custom_') ? getCustomApiInfo(apiId.replace('custom_', ''))?.url : undefined,
+            latencyMs,
+            speedKbps
         }));
         
         // 获取总页数
@@ -69,25 +95,50 @@ async function searchByAPIAndKeyWord(apiId, query) {
                         const pageController = new AbortController();
                         const pageTimeoutId = setTimeout(() => pageController.abort(), 8000);
                         
+                        const pageStart = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
                         const pageResponse = await fetch(PROXY_URL + encodeURIComponent(pageUrl), {
                             headers: API_CONFIG.search.headers,
                             signal: pageController.signal
                         });
-                        
+
                         clearTimeout(pageTimeoutId);
-                        
+
                         if (!pageResponse.ok) return [];
-                        
-                        const pageData = await pageResponse.json();
-                        
+
+                        const pageEnd = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+                        const pageText = await pageResponse.text();
+
+                        let pageData;
+                        try {
+                            pageData = JSON.parse(pageText);
+                        } catch (pageParseError) {
+                            console.warn(`API ${apiId} 第${page}页返回数据解析失败:`, pageParseError);
+                            return [];
+                        }
+
+                        const pageDurationMs = pageEnd - pageStart;
+                        const pageDurationSeconds = pageDurationMs > 0 ? pageDurationMs / 1000 : 0;
+                        let pageSizeBytes = 0;
+                        try {
+                            pageSizeBytes = new TextEncoder().encode(pageText).length;
+                        } catch (encoderError) {
+                            pageSizeBytes = pageText.length * 2;
+                        }
+                        const pageSpeedKbps = pageDurationSeconds > 0
+                            ? Math.round((pageSizeBytes / 1024) / pageDurationSeconds)
+                            : null;
+                        const pageLatencyMs = Math.round(pageDurationMs);
+
                         if (!pageData || !pageData.list || !Array.isArray(pageData.list)) return [];
-                        
+
                         // 处理当前页结果
                         return pageData.list.map(item => ({
                             ...item,
                             source_name: apiName,
                             source_code: apiId,
-                            api_url: apiId.startsWith('custom_') ? getCustomApiInfo(apiId.replace('custom_', ''))?.url : undefined
+                            api_url: apiId.startsWith('custom_') ? getCustomApiInfo(apiId.replace('custom_', ''))?.url : undefined,
+                            latencyMs: pageLatencyMs,
+                            speedKbps: pageSpeedKbps
                         }));
                     } catch (error) {
                         console.warn(`API ${apiId} 第${page}页搜索失败:`, error);

--- a/js/search.js
+++ b/js/search.js
@@ -2,6 +2,101 @@ const getTimestamp = () => (typeof performance !== 'undefined' && typeof perform
     ? performance.now()
     : Date.now();
 
+const computeNetworkMetrics = (requestUrl, requestStart, headersReceived, requestEnd, response, responseText) => {
+    const fallbackLatency = Math.max(0, Math.round(headersReceived - requestStart));
+    const fallbackDownloadSeconds = Math.max((requestEnd - headersReceived) / 1000, 0);
+    const fallbackTotalSeconds = Math.max((requestEnd - requestStart) / 1000, 0);
+
+    let headerSize = 0;
+    if (response && typeof response.headers?.get === 'function') {
+        const lengthHeader = Number(response.headers.get('content-length'));
+        if (!Number.isNaN(lengthHeader) && lengthHeader > 0) {
+            headerSize = lengthHeader;
+        }
+    }
+
+    let encodedSize = 0;
+    if (responseText) {
+        try {
+            encodedSize = new TextEncoder().encode(responseText).length;
+        } catch (encoderError) {
+            encodedSize = responseText.length * 2;
+        }
+    }
+
+    let latencyMs = fallbackLatency;
+    let downloadSeconds = fallbackDownloadSeconds;
+    let totalSeconds = fallbackTotalSeconds;
+    let payloadSizeBytes = headerSize || encodedSize;
+
+    const hasPerformanceNow = typeof performance !== 'undefined' && typeof performance.now === 'function';
+    if (typeof performance !== 'undefined' && typeof performance.getEntriesByName === 'function') {
+        const entries = performance.getEntriesByName(requestUrl) || [];
+        if (entries.length) {
+            const threshold = hasPerformanceNow && typeof requestStart === 'number'
+                ? requestStart - 5
+                : null;
+            let candidate = null;
+            for (const entry of entries) {
+                if (threshold !== null && typeof entry.startTime === 'number' && entry.startTime + 0.01 < threshold) {
+                    continue;
+                }
+                if (!candidate || (entry.responseEnd || 0) > (candidate.responseEnd || 0)) {
+                    candidate = entry;
+                }
+            }
+            if (!candidate) {
+                candidate = entries[entries.length - 1];
+            }
+            if (candidate) {
+                const entryLatency = (candidate.responseStart || 0) - (candidate.startTime || 0);
+                if (Number.isFinite(entryLatency) && entryLatency >= 0) {
+                    latencyMs = Math.max(0, Math.round(entryLatency));
+                }
+                const entryDownload = (candidate.responseEnd || 0) - (candidate.responseStart || 0);
+                if (Number.isFinite(entryDownload) && entryDownload > 0) {
+                    downloadSeconds = Math.max(entryDownload / 1000, downloadSeconds);
+                }
+                const entryTotal = (candidate.responseEnd || 0) - (candidate.startTime || 0);
+                if (Number.isFinite(entryTotal) && entryTotal > 0) {
+                    totalSeconds = Math.max(entryTotal / 1000, totalSeconds);
+                }
+                const entrySize = candidate.transferSize && candidate.transferSize > 0
+                    ? candidate.transferSize
+                    : candidate.encodedBodySize && candidate.encodedBodySize > 0
+                        ? candidate.encodedBodySize
+                        : candidate.decodedBodySize && candidate.decodedBodySize > 0
+                            ? candidate.decodedBodySize
+                            : 0;
+                if (entrySize > 0) {
+                    payloadSizeBytes = entrySize;
+                }
+            }
+        }
+    }
+
+    if (!payloadSizeBytes) {
+        payloadSizeBytes = encodedSize || headerSize;
+    }
+
+    if (downloadSeconds <= 0) {
+        downloadSeconds = totalSeconds - (latencyMs / 1000);
+    }
+    if (downloadSeconds <= 0) {
+        downloadSeconds = totalSeconds;
+    }
+
+    const effectiveSeconds = Math.max(downloadSeconds, 0.01);
+    const speedKBps = payloadSizeBytes > 0
+        ? (payloadSizeBytes / 1024) / effectiveSeconds
+        : null;
+
+    return {
+        latencyMs,
+        speedKBps: Number.isFinite(speedKBps) && speedKBps > 0 ? speedKBps : null
+    };
+};
+
 async function searchByAPIAndKeyWord(apiId, query) {
     try {
         let apiUrl, apiName, apiBaseUrl;
@@ -27,8 +122,9 @@ async function searchByAPIAndKeyWord(apiId, query) {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 8000);
         
+        const requestUrl = PROXY_URL + encodeURIComponent(apiUrl);
         const requestStart = getTimestamp();
-        const response = await fetch(PROXY_URL + encodeURIComponent(apiUrl), {
+        const response = await fetch(requestUrl, {
             headers: API_CONFIG.search.headers,
             signal: controller.signal
         });
@@ -51,21 +147,14 @@ async function searchByAPIAndKeyWord(apiId, query) {
             return [];
         }
 
-        const latencyMs = Math.max(0, Math.round(headersReceived - requestStart));
-        const downloadSeconds = Math.max((requestEnd - headersReceived) / 1000, 0);
-        const totalSeconds = Math.max((requestEnd - requestStart) / 1000, 0);
-        const effectiveSeconds = downloadSeconds > 0 ? downloadSeconds : totalSeconds;
-        let payloadSizeBytes = 0;
-        try {
-            payloadSizeBytes = new TextEncoder().encode(responseText).length;
-        } catch (encoderError) {
-            // TextEncoder 在极少数环境中不可用，回退到字符串长度估算
-            payloadSizeBytes = responseText.length * 2;
-        }
-        const rawSpeed = effectiveSeconds > 0
-            ? (payloadSizeBytes / 1024) / effectiveSeconds
-            : null;
-        const speedKBps = Number.isFinite(rawSpeed) ? rawSpeed : null;
+        const { latencyMs, speedKBps } = computeNetworkMetrics(
+            requestUrl,
+            requestStart,
+            headersReceived,
+            requestEnd,
+            response,
+            responseText
+        );
 
         if (!data || !data.list || !Array.isArray(data.list) || data.list.length === 0) {
             return [];
@@ -103,7 +192,8 @@ async function searchByAPIAndKeyWord(apiId, query) {
                         const pageTimeoutId = setTimeout(() => pageController.abort(), 8000);
                         
                         const pageStart = getTimestamp();
-                        const pageResponse = await fetch(PROXY_URL + encodeURIComponent(pageUrl), {
+                        const pageRequestUrl = PROXY_URL + encodeURIComponent(pageUrl);
+                        const pageResponse = await fetch(pageRequestUrl, {
                             headers: API_CONFIG.search.headers,
                             signal: pageController.signal
                         });
@@ -124,20 +214,14 @@ async function searchByAPIAndKeyWord(apiId, query) {
                             return [];
                         }
 
-                        const pageLatencyMs = Math.max(0, Math.round(pageHeadersReceived - pageStart));
-                        const pageDownloadSeconds = Math.max((pageEnd - pageHeadersReceived) / 1000, 0);
-                        const pageTotalSeconds = Math.max((pageEnd - pageStart) / 1000, 0);
-                        const pageEffectiveSeconds = pageDownloadSeconds > 0 ? pageDownloadSeconds : pageTotalSeconds;
-                        let pageSizeBytes = 0;
-                        try {
-                            pageSizeBytes = new TextEncoder().encode(pageText).length;
-                        } catch (encoderError) {
-                            pageSizeBytes = pageText.length * 2;
-                        }
-                        const pageRawSpeed = pageEffectiveSeconds > 0
-                            ? (pageSizeBytes / 1024) / pageEffectiveSeconds
-                            : null;
-                        const pageSpeedKBps = Number.isFinite(pageRawSpeed) ? pageRawSpeed : null;
+                        const { latencyMs: pageLatencyMs, speedKBps: pageSpeedKBps } = computeNetworkMetrics(
+                            pageRequestUrl,
+                            pageStart,
+                            pageHeadersReceived,
+                            pageEnd,
+                            pageResponse,
+                            pageText
+                        );
 
                         if (!pageData || !pageData.list || !Array.isArray(pageData.list)) return [];
 

--- a/js/search.js
+++ b/js/search.js
@@ -1,3 +1,7 @@
+const getTimestamp = () => (typeof performance !== 'undefined' && typeof performance.now === 'function')
+    ? performance.now()
+    : Date.now();
+
 async function searchByAPIAndKeyWord(apiId, query) {
     try {
         let apiUrl, apiName, apiBaseUrl;
@@ -23,7 +27,7 @@ async function searchByAPIAndKeyWord(apiId, query) {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 8000);
         
-        const requestStart = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+        const requestStart = getTimestamp();
         const response = await fetch(PROXY_URL + encodeURIComponent(apiUrl), {
             headers: API_CONFIG.search.headers,
             signal: controller.signal
@@ -35,8 +39,9 @@ async function searchByAPIAndKeyWord(apiId, query) {
             return [];
         }
 
-        const responseEnd = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+        const headersReceived = getTimestamp();
         const responseText = await response.text();
+        const requestEnd = getTimestamp();
 
         let data;
         try {
@@ -46,8 +51,10 @@ async function searchByAPIAndKeyWord(apiId, query) {
             return [];
         }
 
-        const durationMs = responseEnd - requestStart;
-        const durationSeconds = durationMs > 0 ? durationMs / 1000 : 0;
+        const latencyMs = Math.max(0, Math.round(headersReceived - requestStart));
+        const downloadSeconds = Math.max((requestEnd - headersReceived) / 1000, 0);
+        const totalSeconds = Math.max((requestEnd - requestStart) / 1000, 0);
+        const effectiveSeconds = downloadSeconds > 0 ? downloadSeconds : totalSeconds;
         let payloadSizeBytes = 0;
         try {
             payloadSizeBytes = new TextEncoder().encode(responseText).length;
@@ -55,10 +62,10 @@ async function searchByAPIAndKeyWord(apiId, query) {
             // TextEncoder 在极少数环境中不可用，回退到字符串长度估算
             payloadSizeBytes = responseText.length * 2;
         }
-        const speedKbps = durationSeconds > 0
-            ? Math.round((payloadSizeBytes / 1024) / durationSeconds)
+        const rawSpeed = effectiveSeconds > 0
+            ? (payloadSizeBytes / 1024) / effectiveSeconds
             : null;
-        const latencyMs = Math.round(durationMs);
+        const speedKBps = Number.isFinite(rawSpeed) ? rawSpeed : null;
 
         if (!data || !data.list || !Array.isArray(data.list) || data.list.length === 0) {
             return [];
@@ -71,7 +78,7 @@ async function searchByAPIAndKeyWord(apiId, query) {
             source_code: apiId,
             api_url: apiId.startsWith('custom_') ? getCustomApiInfo(apiId.replace('custom_', ''))?.url : undefined,
             latencyMs,
-            speedKbps
+            speedKBps
         }));
         
         // 获取总页数
@@ -95,7 +102,7 @@ async function searchByAPIAndKeyWord(apiId, query) {
                         const pageController = new AbortController();
                         const pageTimeoutId = setTimeout(() => pageController.abort(), 8000);
                         
-                        const pageStart = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+                        const pageStart = getTimestamp();
                         const pageResponse = await fetch(PROXY_URL + encodeURIComponent(pageUrl), {
                             headers: API_CONFIG.search.headers,
                             signal: pageController.signal
@@ -105,8 +112,9 @@ async function searchByAPIAndKeyWord(apiId, query) {
 
                         if (!pageResponse.ok) return [];
 
-                        const pageEnd = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+                        const pageHeadersReceived = getTimestamp();
                         const pageText = await pageResponse.text();
+                        const pageEnd = getTimestamp();
 
                         let pageData;
                         try {
@@ -116,18 +124,20 @@ async function searchByAPIAndKeyWord(apiId, query) {
                             return [];
                         }
 
-                        const pageDurationMs = pageEnd - pageStart;
-                        const pageDurationSeconds = pageDurationMs > 0 ? pageDurationMs / 1000 : 0;
+                        const pageLatencyMs = Math.max(0, Math.round(pageHeadersReceived - pageStart));
+                        const pageDownloadSeconds = Math.max((pageEnd - pageHeadersReceived) / 1000, 0);
+                        const pageTotalSeconds = Math.max((pageEnd - pageStart) / 1000, 0);
+                        const pageEffectiveSeconds = pageDownloadSeconds > 0 ? pageDownloadSeconds : pageTotalSeconds;
                         let pageSizeBytes = 0;
                         try {
                             pageSizeBytes = new TextEncoder().encode(pageText).length;
                         } catch (encoderError) {
                             pageSizeBytes = pageText.length * 2;
                         }
-                        const pageSpeedKbps = pageDurationSeconds > 0
-                            ? Math.round((pageSizeBytes / 1024) / pageDurationSeconds)
+                        const pageRawSpeed = pageEffectiveSeconds > 0
+                            ? (pageSizeBytes / 1024) / pageEffectiveSeconds
                             : null;
-                        const pageLatencyMs = Math.round(pageDurationMs);
+                        const pageSpeedKBps = Number.isFinite(pageRawSpeed) ? pageRawSpeed : null;
 
                         if (!pageData || !pageData.list || !Array.isArray(pageData.list)) return [];
 
@@ -138,7 +148,7 @@ async function searchByAPIAndKeyWord(apiId, query) {
                             source_code: apiId,
                             api_url: apiId.startsWith('custom_') ? getCustomApiInfo(apiId.replace('custom_', ''))?.url : undefined,
                             latencyMs: pageLatencyMs,
-                            speedKbps: pageSpeedKbps
+                            speedKBps: pageSpeedKBps
                         }));
                     } catch (error) {
                         console.warn(`API ${apiId} 第${page}页搜索失败:`, error);


### PR DESCRIPTION
## Summary
- measure API response latency and estimated transfer speed for each search request
- include the latency and network speed metadata on rendered search result cards

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e546c2b3ec832cb56feb647aca18c7